### PR TITLE
Move coroutines to suspend functions.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,7 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField "String", "BASE_URL", System.env.LECTOR_BASE_URL ?: "\"$lectorUrl\""
+            buildConfigField "String", "BASE_URL_LOCAL", System.env.LECTOR_BASE_URL_LOCAL ?: "\"$lectorUrlLocal\""
         }
     }
 }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
@@ -45,7 +45,7 @@ class RoomCacheEntryClassifierTest {
     fun delete() {
         runBlocking {
             whitelist!!.add("Radish")
-            whitelist!!.delete("Radish").await()
+            whitelist!!.delete("Radish")
             assertFalse(whitelist!!.contains("Radish"))
         }
     }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
@@ -36,7 +36,7 @@ class RoomCacheEntryClassifierTest {
     @Test
     fun add() {
         runBlocking {
-            whitelist!!.add("Potato").await()
+            whitelist!!.add("Potato")
             assertTrue(whitelist!!.contains("Potato"))
         }
     }
@@ -44,7 +44,7 @@ class RoomCacheEntryClassifierTest {
     @Test
     fun delete() {
         runBlocking {
-            whitelist!!.add("Radish").await()
+            whitelist!!.add("Radish")
             whitelist!!.delete("Radish").await()
             assertFalse(whitelist!!.contains("Radish"))
         }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomCacheEntryClassifierTest.kt
@@ -29,7 +29,7 @@ class RoomCacheEntryClassifierTest {
     @Test
     fun contains() {
         runBlocking {
-            assertFalse(whitelist!!.contains("a test string").await())
+            assertFalse(whitelist!!.contains("a test string"))
         }
     }
 
@@ -37,7 +37,7 @@ class RoomCacheEntryClassifierTest {
     fun add() {
         runBlocking {
             whitelist!!.add("Potato").await()
-            assertTrue(whitelist!!.contains("Potato").await())
+            assertTrue(whitelist!!.contains("Potato"))
         }
     }
 
@@ -46,7 +46,7 @@ class RoomCacheEntryClassifierTest {
         runBlocking {
             whitelist!!.add("Radish").await()
             whitelist!!.delete("Radish").await()
-            assertFalse(whitelist!!.contains("Radish").await())
+            assertFalse(whitelist!!.contains("Radish"))
         }
     }
 

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
@@ -81,7 +81,7 @@ class RoomResponseSourceTest {
         runBlocking {
             responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
-            responseSource!!.delete("Dog").await()
+            responseSource!!.delete("Dog")
             assertFalse(responseSource!!.contains("Dog"))
         }
     }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
@@ -58,7 +58,7 @@ class RoomResponseSourceTest {
         var networkResponse : Response? = null
         var cachedResponse : Response? = null
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             // Response from network
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             // Response is in cache now
@@ -71,7 +71,7 @@ class RoomResponseSourceTest {
     fun contains() {
         runBlocking {
             assertFalse(responseSource!!.contains("Dog"))
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
         }
     }
@@ -79,7 +79,7 @@ class RoomResponseSourceTest {
     @Test
     fun delete() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.delete("Dog").await()
             assertFalse(responseSource!!.contains("Dog"))

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
@@ -70,9 +70,9 @@ class RoomResponseSourceTest {
     @Test
     fun contains() {
         runBlocking {
-            assertFalse(responseSource!!.contains("Dog").await())
+            assertFalse(responseSource!!.contains("Dog"))
             responseSource!!.add("Dog").await()
-            assertTrue(responseSource!!.contains("Dog").await())
+            assertTrue(responseSource!!.contains("Dog"))
         }
     }
 
@@ -80,9 +80,9 @@ class RoomResponseSourceTest {
     fun delete() {
         runBlocking {
             responseSource!!.add("Dog").await()
-            assertTrue(responseSource!!.contains("Dog").await())
+            assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.delete("Dog").await()
-            assertFalse(responseSource!!.contains("Dog").await())
+            assertFalse(responseSource!!.contains("Dog"))
         }
     }
 }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomResponseSourceTest.kt
@@ -60,9 +60,9 @@ class RoomResponseSourceTest {
         runBlocking {
             responseSource!!.add("Dog")
             // Response from network
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             // Response is in cache now
-            cachedResponse = savedArticleCache!!.getWithContext(request, "Dog").await()
+            cachedResponse = savedArticleCache!!.getWithContext(request, "Dog")
         }
         assertNotNull(cachedResponse)
     }

--- a/app/src/androidTest/java/com/greglaun/lector/android/room/RoomSavedArticleCacheTest.kt
+++ b/app/src/androidTest/java/com/greglaun/lector/android/room/RoomSavedArticleCacheTest.kt
@@ -41,7 +41,7 @@ class RoomSavedArticleCacheTest {
 
         runBlocking {
             // This should not cause an error
-            cache!!.setWithContext(catRequest!!, catResponse!!, context).await()
+            cache!!.setWithContext(catRequest!!, catResponse!!, context)
         }
     }
 
@@ -53,14 +53,14 @@ class RoomSavedArticleCacheTest {
 
         runBlocking {
 
-            cache!!.addContext(context).await()
-            cache!!.setWithContext(catRequest!!, dogResponse!!, context).await()
-            cache!!.setWithContext(dogRequest!!, catResponse!!, context).await()
+            cache!!.addContext(context)
+            cache!!.setWithContext(catRequest!!, dogResponse!!, context)
+            cache!!.setWithContext(dogRequest!!, catResponse!!, context)
 
-            val result1 = cache!!.getWithContext(catRequest!!, context).await()
+            val result1 = cache!!.getWithContext(catRequest!!, context)
             assertNotNull(result1)
 
-            val result2 = cache!!.getWithContext(dogRequest!!, context).await()
+            val result2 = cache!!.getWithContext(dogRequest!!, context)
             assertNotNull(result2)
         }
     }
@@ -72,16 +72,16 @@ class RoomSavedArticleCacheTest {
         val catResponse = client.newCall(catRequest).execute()
 
         runBlocking {
-            cache!!.addContext(context).await()
-            cache!!.setWithContext(catRequest!!, dogResponse!!, context).await()
-            cache!!.setWithContext(dogRequest!!, catResponse!!, context).await()
+            cache!!.addContext(context)
+            cache!!.setWithContext(catRequest!!, dogResponse!!, context)
+            cache!!.setWithContext(dogRequest!!, catResponse!!, context)
 
             cache!!.garbageCollectContext(context)
 
-            val result1 = cache!!.getWithContext(catRequest!!, context).await()
+            val result1 = cache!!.getWithContext(catRequest!!, context)
             assertNull(result1)
 
-            val result2 = cache!!.getWithContext(dogRequest!!, context).await()
+            val result2 = cache!!.getWithContext(dogRequest!!, context)
             assertNull(result2)
         }
     }

--- a/app/src/main/java/com/greglaun/lector/android/bound/BindableTtsService.kt
+++ b/app/src/main/java/com/greglaun/lector/android/bound/BindableTtsService.kt
@@ -6,7 +6,6 @@ import android.os.Binder
 import android.os.IBinder
 import com.greglaun.lector.data.cache.ResponseSource
 import com.greglaun.lector.ui.speak.*
-import kotlinx.coroutines.experimental.Deferred
 
 class BindableTtsService : Service(), TtsStateMachine {
     private val binder = LocalBinder()
@@ -22,7 +21,7 @@ class BindableTtsService : Service(), TtsStateMachine {
         delegateStateMachine!!.stopMachine()
     }
 
-    override fun getSpeakerState(): Deferred<SpeakerState> {
+    override suspend fun getSpeakerState(): SpeakerState {
         return delegateStateMachine!!.getSpeakerState()
     }
 
@@ -30,27 +29,27 @@ class BindableTtsService : Service(), TtsStateMachine {
         return delegateStateMachine!!.updateArticle(articleState)
     }
 
-    override fun actionSpeakOne(): Deferred<SpeakerState> {
+    override suspend fun actionSpeakOne(): SpeakerState {
         return delegateStateMachine!!.actionSpeakOne()
     }
 
-    override fun actionStopSpeaking(): Deferred<Unit?> {
+    override suspend fun actionStopSpeaking() {
         return delegateStateMachine!!.actionStopSpeaking()
     }
 
-    override fun actionSpeakInLoop(onPositionUpdate: ((String) -> Unit)?): Deferred<Unit> {
+    override suspend fun actionSpeakInLoop(onPositionUpdate: ((String) -> Unit)?) {
         return delegateStateMachine!!.actionSpeakInLoop(onPositionUpdate)
     }
 
-    override fun getArticleState(): Deferred<ArticleState> {
+    override suspend fun getArticleState(): ArticleState {
         return delegateStateMachine!!.getArticleState()
     }
 
-    override fun stopAdvanceOneAndResume(onDone: (ArticleState) -> Unit): Deferred<Unit> {
+    override suspend fun stopAdvanceOneAndResume(onDone: (ArticleState) -> Unit) {
         return delegateStateMachine!!.stopAdvanceOneAndResume(onDone)
     }
 
-    override fun stopReverseOneAndResume(onDone: (ArticleState) -> Unit): Deferred<Unit> {
+    override suspend fun stopReverseOneAndResume(onDone: (ArticleState) -> Unit) {
         return delegateStateMachine!!.stopReverseOneAndResume(onDone)
     }
 

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -20,10 +20,8 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
         }
     }
 
-    override fun delete(element: String): Deferred<Unit> {
-        return GlobalScope.async{
-            db.articleContextDao().delete(element)
-        }
+    override suspend fun delete(element: String) {
+        return db.articleContextDao().delete(element)
     }
 
     override fun update(from: String, to: String): Deferred<Unit> {

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -7,10 +7,8 @@ import kotlinx.coroutines.experimental.GlobalScope
 import kotlinx.coroutines.experimental.async
 
 class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<String> {
-    override fun contains(element: String): Deferred<Boolean> {
-        return GlobalScope.async{
-            db.articleContextDao().get(element) != null
-        }
+    override suspend fun contains(element: String): Boolean {
+       return db.articleContextDao().get(element) != null
     }
 
     override fun add(element: String): Deferred<Long> {

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -24,14 +24,11 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
         return db.articleContextDao().delete(element)
     }
 
-    override fun update(from: String, to: String): Deferred<Unit> {
-        return GlobalScope.async {
-            val articleContext = db.articleContextDao().get(from)
-            articleContext?.let {
-                articleContext.contextString = to
-                db.articleContextDao().updateArticleContext(articleContext)
-            }
-            Unit
+    override suspend fun update(from: String, to: String) {
+        val articleContext = db.articleContextDao().get(from)
+        articleContext?.let {
+            articleContext.contextString = to
+            db.articleContextDao().updateArticleContext(articleContext)
         }
     }
 

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -2,9 +2,6 @@ package com.greglaun.lector.android.room
 
 import com.greglaun.lector.data.cache.ArticleContext
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 
 class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<String> {
     override suspend fun contains(element: String): Boolean {
@@ -60,20 +57,16 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
         return db.articleContextDao().updatePosition(currentRequestContext, position)
     }
 
-    override fun getUnfinished(): Deferred<List<String>> {
-        return GlobalScope.async {
-            val unfinished = mutableListOf<String>()
-            db.articleContextDao().getAllUnfinished().map {
-                unfinished.add(it.contextString)
-            }
-            unfinished
+    override suspend fun getUnfinished(): List<String> {
+        val unfinished = mutableListOf<String>()
+        db.articleContextDao().getAllUnfinished().map {
+            unfinished.add(it.contextString)
         }
+        return unfinished
     }
 
-    override fun markFinished(element: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().markFinished(element)
-        }
+    override suspend fun markFinished(element: String) {
+        db.articleContextDao().markFinished(element)
     }
 
     override suspend fun getNextArticle(context: String): ArticleContext? {

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -32,46 +32,32 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
         }
     }
 
-    override fun getAllTemporary(): Deferred<List<ArticleContext>> {
-        return GlobalScope.async {
-            db.articleContextDao().getAllTemporary()
-        }
+    override suspend fun getAllTemporary(): List<ArticleContext> {
+        return db.articleContextDao().getAllTemporary()
     }
 
-    override fun markTemporary(element: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().markTemporary(element)
-        }
+    override suspend fun markTemporary(element: String) {
+        return db.articleContextDao().markTemporary(element)
     }
 
-    override fun markPermanent(element: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().markPermanent(element)
-        }
+    override suspend fun markPermanent(element: String) {
+        return db.articleContextDao().markPermanent(element)
     }
 
-    override fun isTemporary(element: String): Deferred<Boolean> {
-        return GlobalScope.async {
-            db.articleContextDao().isTemporary(element)
-        }
+    override suspend fun isTemporary(element: String): Boolean {
+        return db.articleContextDao().isTemporary(element)
     }
 
-    override fun getAllPermanent(): Deferred<List<ArticleContext>> {
-        return GlobalScope.async {
-            db.articleContextDao().getAllPermanent()
-        }
+    override suspend  fun getAllPermanent(): List<ArticleContext> {
+        return db.articleContextDao().getAllPermanent()
     }
 
-    override fun getArticleContext(context: String): Deferred<ArticleContext?> {
-        return GlobalScope.async {
-            db.articleContextDao().get(context)
-        }
+    override suspend fun getArticleContext(context: String): ArticleContext? {
+        return db.articleContextDao().get(context)
     }
 
-    override fun updatePosition(currentRequestContext: String, position: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().updatePosition(currentRequestContext, position)
-        }
+    override suspend fun updatePosition(currentRequestContext: String, position: String) {
+        return db.articleContextDao().updatePosition(currentRequestContext, position)
     }
 
     override fun getUnfinished(): Deferred<List<String>> {
@@ -90,13 +76,11 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
         }
     }
 
-    override fun getNextArticle(context: String): Deferred<ArticleContext?> {
-        return GlobalScope.async {
-            val oldArticle = db.articleContextDao().get(context) ?: return@async null
+    override suspend fun getNextArticle(context: String): ArticleContext? {
+        val oldArticle = db.articleContextDao().get(context) ?: return null
             if (oldArticle.temporary) {
-                return@async null
+                return null
             }
-            db.articleContextDao().getNextLargestInUniverse(oldArticle.id!!)
-        }
+        return db.articleContextDao().getNextLargestInUniverse(oldArticle.id!!)
     }
 }

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCacheEntryClassifier.kt
@@ -11,14 +11,12 @@ class RoomCacheEntryClassifier(val db: LectorDatabase): CacheEntryClassifier<Str
        return db.articleContextDao().get(element) != null
     }
 
-    override fun add(element: String): Deferred<Long> {
-        return GlobalScope.async {
-            val existingEntry = db.articleContextDao().get(element)
-            if (existingEntry == null) {
-                db.articleContextDao().insert(RoomArticleContext(null, contextString = element))
-            } else {
-                existingEntry.id!!
-            }
+    override suspend fun add(element: String): Long {
+        val existingEntry = db.articleContextDao().get(element)
+        if (existingEntry == null) {
+            return db.articleContextDao().insert(RoomArticleContext(null, contextString = element))
+        } else {
+            return existingEntry.id!!
         }
     }
 

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomCourseSource.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomCourseSource.kt
@@ -5,21 +5,14 @@ import com.greglaun.lector.data.cache.urlToContext
 import com.greglaun.lector.data.course.CourseContext
 import com.greglaun.lector.data.course.CourseSource
 import com.greglaun.lector.data.course.ThinCourseDetails
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 
 class RoomCourseSource(var db: LectorDatabase) : CourseSource {
-    override fun getCourses(): Deferred<List<CourseContext>> {
-        return GlobalScope.async{
-            db.courseContextDao().getAll()
-        }
+    override suspend fun getCourses(): List<CourseContext> {
+        return db.courseContextDao().getAll()
     }
 
-    override fun getArticlesForCourse(courseId: Long): Deferred<List<ArticleContext>> {
-        return GlobalScope.async {
-            db.courseArticleJoinDao().getArticlesWithCourseId(courseId)
-        }
+    override suspend fun getArticlesForCourse(courseId: Long): List<ArticleContext> {
+        return db.courseArticleJoinDao().getArticlesWithCourseId(courseId)
     }
 
     override suspend fun getNextInCourse(courseName: String,
@@ -35,55 +28,46 @@ class RoomCourseSource(var db: LectorDatabase) : CourseSource {
         return db.courseArticleJoinDao().getNextInCourse(courseContext.id!!, articleContext.id!!)
     }
 
-    override fun addArticleForSource(courseName: String, articleName: String): Deferred<Unit> {
-        return GlobalScope.async {
-            var articleContext: ArticleContext? = db.articleContextDao().get(articleName)
-            if (articleContext == null) {
-                val articleId = db.articleContextDao().insert(
-                        RoomArticleContext(null, articleName, "", false))
-                articleContext =
-                        RoomArticleContext(articleId, articleName, "", false)
-            }
-            val courseContext = db.courseContextDao().get(courseName)
-            val maxOccupied = db.courseArticleJoinDao().getMaxOccupiedPosition(
+    override suspend fun addArticleForSource(courseName: String, articleName: String) {
+        var articleContext: ArticleContext? = db.articleContextDao().get(articleName)
+        if (articleContext == null) {
+            val articleId = db.articleContextDao().insert(
+                    RoomArticleContext(null, articleName, "", false))
+            articleContext =
+                    RoomArticleContext(articleId, articleName, "", false)
+        }
+        val courseContext = db.courseContextDao().get(courseName)
+        val maxOccupied = db.courseArticleJoinDao().getMaxOccupiedPosition(
                     courseContext.id!!) ?: -1L
-            val courseArticleJoin = CourseArticleJoin(courseContext.id!!,
-                    articleContext.id!!, maxOccupied + 1)
-            val existingEntry = db.courseArticleJoinDao().get(courseContext.id!!,
-                    articleContext.id!!)
-            if (existingEntry == null) {
-                db.courseArticleJoinDao().insert(courseArticleJoin)
-            }
-            Unit
+        val courseArticleJoin = CourseArticleJoin(courseContext.id!!,
+                articleContext.id!!, maxOccupied + 1)
+        val existingEntry = db.courseArticleJoinDao().get(courseContext.id!!,
+                articleContext.id!!)
+        if (existingEntry == null) {
+            db.courseArticleJoinDao().insert(courseArticleJoin)
         }
     }
 
-    override fun delete(courseName: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.courseContextDao().delete(courseName)
+    override suspend fun delete(courseName: String) {
+        db.courseContextDao().delete(courseName)
+    }
+
+    override suspend fun add(courseContext: CourseContext): Long {
+        val existingEntry = db.courseContextDao().get(courseContext.courseName)
+        if (existingEntry == null) {
+            val roomCourse = RoomCourseContext(null, courseName = courseContext.courseName,
+                    position = courseContext.position)
+            val newId = db.courseContextDao().insert(roomCourse)
+            return newId
+        } else {
+            return existingEntry.id!!
         }
     }
 
-    override fun add(courseContext: CourseContext): Deferred<Long> {
-        return GlobalScope.async {
-            val existingEntry = db.courseContextDao().get(courseContext.courseName)
-            if (existingEntry == null) {
-                val roomCourse = RoomCourseContext(null, courseName = courseContext.courseName,
-                        position = courseContext.position)
-                val newId = db.courseContextDao().insert(roomCourse)
-                newId
-            } else {
-                existingEntry.id!!
-            }
-        }
-    }
-
-    override fun addCourseDetails(courseDetails: ThinCourseDetails): Deferred<Unit> {
-        return GlobalScope.async {
-            add(RoomCourseContext(null, courseDetails.name)).await()
-            courseDetails.articleNames.forEach {
-                addArticleForSource(courseDetails.name, urlToContext(it))
-            }
+    override suspend fun addCourseDetails(courseDetails: ThinCourseDetails) {
+        add(RoomCourseContext(null, courseDetails.name))
+        courseDetails.articleNames.forEach {
+            addArticleForSource(courseDetails.name, urlToContext(it))
         }
     }
 }

--- a/app/src/main/java/com/greglaun/lector/android/room/RoomSavedArticleCache.kt
+++ b/app/src/main/java/com/greglaun/lector/android/room/RoomSavedArticleCache.kt
@@ -7,62 +7,44 @@ import com.greglaun.lector.data.cache.md5
 import com.greglaun.lector.data.cache.serialize
 import com.greglaun.lector.data.cache.toResponse
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import okhttp3.Request
 import okhttp3.Response
 
 class RoomSavedArticleCache(var db: LectorDatabase) :
         SavedArticleCache<Request, Response, String> {
 
-    override fun getWithContext(key: Request, keyContext: String): Deferred<Response?> {
-       return GlobalScope.async {
-            val cachedResponse = db.cachedResponseDao().get(key.url().toString().md5())
-           cachedResponse?.response?.toResponse()
-        }
+    override suspend fun getWithContext(key: Request, keyContext: String): Response? {
+        val cachedResponse = db.cachedResponseDao().get(key.url().toString().md5())
+        return cachedResponse?.response?.toResponse()
     }
 
-    override fun setWithContext(key: Request, value: Response, keyContext: String): Deferred<Unit> {
-        return GlobalScope.async {
-            var articleId: Long? = null
-            try {
-                articleId = db.articleContextDao().get(keyContext)?.id
-                if (articleId == null) {
-                    articleId = db.articleContextDao().insert(
-                            RoomArticleContext(null, keyContext, "", true))
-                }
-                val cachedResponse = CachedResponse(null, key.url().toString().md5(),
-                        value.serialize(), articleId!!)
-                db.cachedResponseDao().insert(cachedResponse)
-            } catch (e : SQLiteConstraintException) {
-                Log.d("RoomSavedArticleCache", keyContext, e)
-                throw e
+    override suspend fun setWithContext(key: Request, value: Response, keyContext: String) {
+        var articleId: Long? = null
+        try {
+            articleId = db.articleContextDao().get(keyContext)?.id
+            if (articleId == null) {
+                articleId = db.articleContextDao().insert(
+                        RoomArticleContext(null, keyContext, "", true))
             }
-            Unit
+            val cachedResponse = CachedResponse(null, key.url().toString().md5(),
+                    value.serialize(), articleId!!)
+            return db.cachedResponseDao().insert(cachedResponse)
+        } catch (e : SQLiteConstraintException) {
+            Log.d("RoomSavedArticleCache", keyContext, e)
+            throw e
         }
     }
 
-    override fun garbageCollectContext(keyContext: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().delete(keyContext)
-            CompletableDeferred(Unit)
-            Unit
-        }
+    override suspend fun garbageCollectContext(keyContext: String) {
+        db.articleContextDao().delete(keyContext)
     }
 
-    override fun addContext(keyContext: String): Deferred<Unit> {
-        return GlobalScope.async {
-            db.articleContextDao().insert(RoomArticleContext(null, keyContext))
-            Unit
-        }
+    override suspend fun addContext(keyContext: String) {
+        db.articleContextDao().insert(RoomArticleContext(null, keyContext))
     }
 
-    override fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>): Deferred<Unit> {
-        return GlobalScope.async {
-            // Ignore the passed-in classifier, since we already have access to the db
-            db.articleContextDao().deleteAllTemporary()
-        }
+    override suspend fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>) {
+        // Ignore the passed-in classifier, since we already have access to the db
+        db.articleContextDao().deleteAllTemporary()
     }
 }

--- a/app/src/main/java/com/greglaun/lector/android/webview/WikiWebViewClient.kt
+++ b/app/src/main/java/com/greglaun/lector/android/webview/WikiWebViewClient.kt
@@ -30,7 +30,7 @@ class WikiWebViewClient(val mainPresenter: MainContract.Presenter,
     override fun shouldInterceptRequest(view: WebView, request: WebResourceRequest): WebResourceResponse? {
         if (request.url.authority.endsWith("wikipedia.org")) {
             return runBlocking {
-                val response = mainPresenter.onRequest(request.url.toString()).await()
+                val response = mainPresenter.onRequest(request.url.toString())
                 if (response == null) {
                     null
                 } else {

--- a/app/src/main/java/com/greglaun/lector/data/cache/HashMapSavedArticleCache.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/HashMapSavedArticleCache.kt
@@ -60,7 +60,8 @@ class HashMapSavedArticleCache : SavedArticleCache<Request, Response, String> {
                 val iterator = it.value.second.iterator()
                 while (iterator.hasNext()) {
                     val it = iterator.next()
-                    if (classifier.isTemporary(it).await()) {
+                    if (classifier.isTemporary(it)
+                    ) {
                         iterator.remove()
                     }
                 }

--- a/app/src/main/java/com/greglaun/lector/data/cache/HashMapSavedArticleCache.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/HashMapSavedArticleCache.kt
@@ -1,10 +1,6 @@
 package com.greglaun.lector.data.cache
 
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import okhttp3.Request
 import okhttp3.Response
 import java.util.*
@@ -13,19 +9,18 @@ import java.util.*
 class HashMapSavedArticleCache : SavedArticleCache<Request, Response, String> {
     val hashCache : HashMap<Request, Pair<String, HashSet<String>>> = HashMap()
 
-    override fun getWithContext(key: Request, keyContext : String)
-            : Deferred<Response?> {
+    override suspend fun getWithContext(key: Request, keyContext : String): Response? {
         if (!hashCache.containsKey(key)) {
-            return CompletableDeferred(value = null)
+            return null
         }
         if (!hashCache.get(key)!!.second.contains(keyContext)) {
-            return CompletableDeferred(value = null)
+            return null
         }
-        return CompletableDeferred(hashCache.get(key)!!.first.toResponse())
+        return hashCache.get(key)!!.first.toResponse()
 
     }
 
-    override fun setWithContext(key: Request, value: Response, keyContext : String): Deferred<Unit> {
+    override suspend fun setWithContext(key: Request, value: Response, keyContext : String) {
         if (hashCache.containsKey(key)) {
             val cacheEntry = hashCache.get(key)!!
             cacheEntry.second.add(keyContext)
@@ -34,10 +29,9 @@ class HashMapSavedArticleCache : SavedArticleCache<Request, Response, String> {
             set.add(keyContext)
             hashCache.put(key, Pair(value.serialize(), set))
         }
-        return CompletableDeferred(Unit)
     }
 
-    override fun garbageCollectContext(keyContext : String): Deferred<Unit> {
+    override suspend fun garbageCollectContext(keyContext : String) {
         val iterator = hashCache.iterator()
         while (iterator.hasNext()) {
             val entry = iterator.next()
@@ -46,28 +40,23 @@ class HashMapSavedArticleCache : SavedArticleCache<Request, Response, String> {
                     iterator.remove()
                 }
         }
-        return CompletableDeferred(Unit)
     }
 
-    override fun addContext(keyContext: String): Deferred<Unit> {
+    override suspend fun addContext(keyContext: String) {
         // Do nothing
-        return CompletableDeferred(Unit)
     }
 
-    override fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>): Deferred<Unit> {
-        return GlobalScope.async {
-            hashCache.forEach {
-                val iterator = it.value.second.iterator()
-                while (iterator.hasNext()) {
-                    val it = iterator.next()
-                    if (classifier.isTemporary(it)
-                    ) {
-                        iterator.remove()
-                    }
+    override suspend fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>) {
+        return hashCache.forEach {
+            val iterator = it.value.second.iterator()
+            while (iterator.hasNext()) {
+                val it = iterator.next()
+                if (classifier.isTemporary(it)
+                ) {
+                    iterator.remove()
                 }
             }
         }
     }
-
 }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/NetworkCache.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/NetworkCache.kt
@@ -1,9 +1,5 @@
 package com.greglaun.lector.data.cache
 
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -14,17 +10,15 @@ import okhttp3.Response
 open class NetworkCache(val httpClient : OkHttpClient)
     : ComposableCache<Request, Response> {
 
-    override fun get(key: Request): Deferred<Response?> {
-        return GlobalScope.async {
-            try {
-                httpClient.newCall(key).execute()
-            } catch (e: Exception) {
-                null
-            }
+    override suspend fun get(key: Request): Response? {
+        try {
+            return httpClient.newCall(key).execute()
+        } catch (e: Exception) {
+            return null
         }
     }
-    override fun set(key: Request, value: Response): Deferred<Unit> {
+
+    override suspend fun set(key: Request, value: Response) {
         // Do nothing
-        return CompletableDeferred(Unit)
     }
 }

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSource.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSource.kt
@@ -1,12 +1,11 @@
 package com.greglaun.lector.data.cache
 
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
-import kotlinx.coroutines.experimental.Deferred
 import okhttp3.Request
 import okhttp3.Response
 
 interface ResponseSource: CacheEntryClassifier<String>, ContextAwareCache<Request, Response, String> {
-    fun garbageCollectTemporary(): Deferred<Unit> {
+    suspend fun garbageCollectTemporary() {
         return garbageCollectTemporary(this)
     }
 }

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -35,7 +35,7 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.contains(element)
     }
 
-    override fun add(element: String): Deferred<Long> {
+    override suspend fun add(element: String): Long {
         return cacheEntryClassifier.add(element)
     }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -31,7 +31,7 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         }
     }
 
-    override fun contains(element: String): Deferred<Boolean> {
+    override suspend fun contains(element: String): Boolean {
         return cacheEntryClassifier.contains(element)
     }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -2,7 +2,6 @@ package com.greglaun.lector.data.cache
 
 import com.greglaun.lector.data.net.OkHttpConnectionFactory
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
-import kotlinx.coroutines.experimental.Deferred
 import okhttp3.Request
 import okhttp3.Response
 import java.io.File
@@ -93,11 +92,11 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.updatePosition(context, position)
     }
 
-    override fun getUnfinished(): Deferred<List<String>> {
+    override suspend fun getUnfinished(): List<String> {
         return cacheEntryClassifier.getUnfinished()
     }
 
-    override fun markFinished(element: String): Deferred<Unit> {
+    override suspend fun markFinished(element: String) {
         return cacheEntryClassifier.markFinished(element)
     }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -53,11 +53,11 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         cacheEntryClassifier.update(from, to)
     }
 
-    override fun markTemporary(keyContext: String): Deferred<Unit> {
+    override suspend fun markTemporary(keyContext: String) {
         return cacheEntryClassifier.markTemporary(keyContext)
     }
 
-    override fun markPermanent(keyContext: String): Deferred<Unit> {
+    override suspend fun markPermanent(keyContext: String) {
         return cacheEntryClassifier.markPermanent(keyContext)
     }
 
@@ -73,23 +73,23 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return articleCache.garbageCollectTemporary(classifier)
     }
 
-    override fun getAllTemporary(): Deferred<List<ArticleContext>> {
+    override suspend fun getAllTemporary(): List<ArticleContext> {
         return cacheEntryClassifier.getAllTemporary()
     }
 
-    override fun isTemporary(element: String): Deferred<Boolean> {
+    override suspend fun isTemporary(element: String): Boolean {
         return cacheEntryClassifier.isTemporary(element)
     }
 
-    override fun getAllPermanent(): Deferred<List<ArticleContext>> {
+    override suspend fun getAllPermanent(): List<ArticleContext> {
         return cacheEntryClassifier.getAllPermanent()
     }
 
-    override fun getArticleContext(context: String): Deferred<ArticleContext?> {
+    override suspend fun getArticleContext(context: String): ArticleContext? {
         return cacheEntryClassifier.getArticleContext(context)
     }
 
-    override fun updatePosition(context: String, position: String): Deferred<Unit> {
+    override suspend fun updatePosition(context: String, position: String) {
         return cacheEntryClassifier.updatePosition(context, position)
     }
 
@@ -101,7 +101,7 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.markFinished(element)
     }
 
-    override fun getNextArticle(context: String): Deferred<ArticleContext?> {
+    override suspend fun getNextArticle(context: String): ArticleContext? {
         return cacheEntryClassifier.getNextArticle(context)
     }
 }

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -39,7 +39,7 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.add(element)
     }
 
-    override fun delete(element: String): Deferred<Unit> {
+    override suspend fun delete(element: String) {
         return cacheEntryClassifier.delete(element)
     }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -3,8 +3,6 @@ package com.greglaun.lector.data.cache
 import com.greglaun.lector.data.net.OkHttpConnectionFactory
 import com.greglaun.lector.data.whitelist.CacheEntryClassifier
 import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import okhttp3.Request
 import okhttp3.Response
 import java.io.File
@@ -51,10 +49,8 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return articleCache.setWithContext(key, value, keyContext)
     }
 
-    override fun update(from: String, to: String): Deferred<Unit> {
-       return GlobalScope.async {
-            cacheEntryClassifier.update(from, to).await()
-        }
+    override suspend fun update(from: String, to: String) {
+        cacheEntryClassifier.update(from, to)
     }
 
     override fun markTemporary(keyContext: String): Deferred<Unit> {

--- a/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/ResponseSourceImpl.kt
@@ -41,11 +41,11 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.delete(element)
     }
 
-    override fun getWithContext(key: Request, keyContext: String): Deferred<Response?> {
+    override suspend fun getWithContext(key: Request, keyContext: String): Response? {
         return articleCache.getWithContext(key, keyContext)
     }
 
-    override fun setWithContext(key: Request, value: Response, keyContext: String): Deferred<Unit> {
+    override suspend fun setWithContext(key: Request, value: Response, keyContext: String) {
         return articleCache.setWithContext(key, value, keyContext)
     }
 
@@ -61,15 +61,15 @@ class ResponseSourceImpl(val articleCache: ContextAwareCache<Request, Response, 
         return cacheEntryClassifier.markPermanent(keyContext)
     }
 
-    override fun garbageCollectTemporary(): Deferred<Unit> {
+    override suspend fun garbageCollectTemporary() {
         return articleCache.garbageCollectTemporary(cacheEntryClassifier)
     }
 
-    override fun garbageCollectContext(keyContext: String): Deferred<Unit> {
+    override suspend fun garbageCollectContext(keyContext: String) {
         return articleCache.garbageCollectContext(keyContext)
     }
 
-    override fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>): Deferred<Unit> {
+    override suspend fun garbageCollectTemporary(classifier: CacheEntryClassifier<String>) {
         return articleCache.garbageCollectTemporary(classifier)
     }
 

--- a/app/src/main/java/com/greglaun/lector/data/cache/SavedArticleCache.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/SavedArticleCache.kt
@@ -1,13 +1,11 @@
 package com.greglaun.lector.data.cache
 
-import kotlinx.coroutines.experimental.Deferred
-
 interface SavedArticleCache<Key : Any, Value : Any, KeyContext : Any>
     : ContextAwareCache<Key, Value, KeyContext> {
 
     // Add the key contextString to the cache, so that it is available to entries that need it.
     // This is for caches that are normalized.
-    fun addContext(keyContext: KeyContext): Deferred<Unit>
+    suspend fun addContext(keyContext: KeyContext)
 
     // Garbage collect the items from the given contextString provided they are not referred to by another
     // contextString. This prevents us from deleting items that are still needed in other contexts.
@@ -18,5 +16,5 @@ interface SavedArticleCache<Key : Any, Value : Any, KeyContext : Any>
     //
     // Basic algorithm: iterate through the list. If the given contextString is the only contextString
     // associated with an item, delete that item. Otherwise remove the contextString from that item.
-    fun garbageCollectContext(keyContext : KeyContext): Deferred<Unit>
+    suspend fun garbageCollectContext(keyContext : KeyContext)
 }

--- a/app/src/main/java/com/greglaun/lector/data/cache/TestingNetworkCache.kt
+++ b/app/src/main/java/com/greglaun/lector/data/cache/TestingNetworkCache.kt
@@ -1,9 +1,5 @@
 package com.greglaun.lector.data.cache
 
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.GlobalScope
-import kotlinx.coroutines.experimental.async
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -11,23 +7,19 @@ import okhttp3.Response
 class TestingNetworkCache(httpClient: OkHttpClient) : NetworkCache(httpClient) {
     var disableNetwork = false
 
-    override fun get(key: Request): Deferred<Response?> {
+    override suspend fun get(key: Request): Response? {
         if (disableNetwork) {
-            val response: Response? = null
-            return CompletableDeferred(response)
+            return null
         }
-        return GlobalScope.async {
-            try {
-                httpClient.newCall(key).execute()
-            } catch (e: Exception) {
-                null
-            }
+        try {
+            return httpClient.newCall(key).execute()
+        } catch (e: Exception) {
+            return null
         }
     }
 
-    override fun set(key: Request, value: Response): Deferred<Unit> {
+    override suspend fun set(key: Request, value: Response) {
         // Do nothing
-        return CompletableDeferred(Unit)
     }
 
     fun disableNetwork(shouldDisable: Boolean) {

--- a/app/src/main/java/com/greglaun/lector/data/course/CourseDownloader.kt
+++ b/app/src/main/java/com/greglaun/lector/data/course/CourseDownloader.kt
@@ -1,11 +1,8 @@
 package com.greglaun.lector.data.course
 
-import kotlinx.coroutines.experimental.Deferred
-
 interface CourseDownloader {
     // todo(REST): Add ability to send a query string
-    fun downloadCourseMetadata(): Deferred<List<CourseMetadata>?>
-    fun fetchCourseDetails(courseNames: List<String>):
-            Deferred<Map<String, ThinCourseDetails>?>
-    fun fetchCourseDetails(courseMetadata: CourseMetadata):  Deferred<ThinCourseDetails?>
+    suspend fun downloadCourseMetadata(): List<CourseMetadata>?
+    suspend fun fetchCourseDetails(courseNames: List<String>): Map<String, ThinCourseDetails>?
+    suspend fun fetchCourseDetails(courseMetadata: CourseMetadata): ThinCourseDetails?
 }

--- a/app/src/main/java/com/greglaun/lector/data/course/CourseSource.kt
+++ b/app/src/main/java/com/greglaun/lector/data/course/CourseSource.kt
@@ -1,15 +1,13 @@
 package com.greglaun.lector.data.course
 
 import com.greglaun.lector.data.cache.ArticleContext
-import kotlinx.coroutines.experimental.Deferred
 
 interface CourseSource {
-    fun getCourses(): Deferred<List<CourseContext>>
-    fun getArticlesForCourse(courseId: Long): Deferred<List<ArticleContext>>
-    fun delete(courseName: String): Deferred<Unit>
-    fun add(courseContext: CourseContext): Deferred<Long>
-    fun addArticleForSource(courseName: String, articleName: String): Deferred<Unit>
-    fun addCourseDetails(courseDetails: ThinCourseDetails): Deferred<Unit>
-    suspend fun getNextInCourse(courseName: String, articleName: String):
-            ArticleContext?
+    suspend fun getCourses(): List<CourseContext>
+    suspend fun getArticlesForCourse(courseId: Long): List<ArticleContext>
+    suspend fun delete(courseName: String)
+    suspend fun add(courseContext: CourseContext): Long
+    suspend fun addArticleForSource(courseName: String, articleName: String)
+    suspend fun addCourseDetails(courseDetails: ThinCourseDetails)
+    suspend fun getNextInCourse(courseName: String, articleName: String): ArticleContext?
 }

--- a/app/src/main/java/com/greglaun/lector/data/net/DownloadCompletionScheduler.kt
+++ b/app/src/main/java/com/greglaun/lector/data/net/DownloadCompletionScheduler.kt
@@ -1,5 +1,7 @@
 package com.greglaun.lector.data.net
 
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.runBlocking
 import java.util.*
 import kotlin.concurrent.fixedRateTimer
@@ -14,9 +16,11 @@ class DownloadCompletionScheduler(
         fixedRateTimer = fixedRateTimer(name = "download-finish-timer",
                 initialDelay = 100, period = 15 * 1000, daemon = true) {
             runBlocking {
-                downloadCompleter.addUrlsFOrDownload(unfinishedDownloadSource.getUnfinished().await())
+                downloadCompleter.addUrlsFOrDownload(unfinishedDownloadSource.getUnfinished())
                 downloadCompleter.downloadNextUrl { it ->
-                    unfinishedDownloadSource.markFinished(it)
+                    GlobalScope.launch {
+                        unfinishedDownloadSource.markFinished(it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/greglaun/lector/data/net/UnfinishedDownloadSource.kt
+++ b/app/src/main/java/com/greglaun/lector/data/net/UnfinishedDownloadSource.kt
@@ -1,8 +1,6 @@
 package com.greglaun.lector.data.net
 
-import kotlinx.coroutines.experimental.Deferred
-
 interface UnfinishedDownloadSource {
-    fun getUnfinished(): Deferred<List<String>>
-    fun markFinished(urlString: String): Deferred<Unit>
+    suspend fun getUnfinished(): List<String>
+    suspend fun markFinished(urlString: String)
 }

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.experimental.Deferred
 interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     // todo(cleanup): Move ArticleContext functions to another interface? Or re-architect?
     suspend fun contains(element : T): Boolean
-    fun add(element: T): Deferred<Long>
+    suspend fun add(element: T): Long
     fun delete(element: T): Deferred<Unit>
     fun update(from: T, to: T): Deferred<Unit>
     fun getAllTemporary(): Deferred<List<ArticleContext>>

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.experimental.Deferred
 
 interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     // todo(cleanup): Move ArticleContext functions to another interface? Or re-architect?
-    fun contains(element : T): Deferred<Boolean>
+    suspend fun contains(element : T): Boolean
     fun add(element: T): Deferred<Long>
     fun delete(element: T): Deferred<Unit>
     fun update(from: T, to: T): Deferred<Unit>

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
@@ -2,7 +2,6 @@ package com.greglaun.lector.data.whitelist
 
 import com.greglaun.lector.data.cache.ArticleContext
 import com.greglaun.lector.data.net.UnfinishedDownloadSource
-import kotlinx.coroutines.experimental.Deferred
 
 interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     // todo(cleanup): Move ArticleContext functions to another interface? Or re-architect?
@@ -10,12 +9,12 @@ interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     suspend fun add(element: T): Long
     suspend fun delete(element: T)
     suspend fun update(from: T, to: T)
-    fun getAllTemporary(): Deferred<List<ArticleContext>>
-    fun getAllPermanent(): Deferred<List<ArticleContext>>
-    fun markTemporary(element: T): Deferred<Unit>
-    fun markPermanent(element: T): Deferred<Unit>
-    fun isTemporary(element: T): Deferred<Boolean>
-    fun getArticleContext(context: String): Deferred<ArticleContext?>
-    fun updatePosition(currentRequestContext: T, position: T): Deferred<Unit>
-    fun getNextArticle(context: String): Deferred<ArticleContext?>
+    suspend fun getAllTemporary(): List<ArticleContext>
+    suspend fun getAllPermanent(): List<ArticleContext>
+    suspend fun markTemporary(element: T)
+    suspend fun markPermanent(element: T)
+    suspend fun isTemporary(element: T): Boolean
+    suspend fun getArticleContext(context: String): ArticleContext?
+    suspend fun updatePosition(currentRequestContext: T, position: T)
+    suspend fun getNextArticle(context: String): ArticleContext?
 }

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
@@ -8,7 +8,7 @@ interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     // todo(cleanup): Move ArticleContext functions to another interface? Or re-architect?
     suspend fun contains(element : T): Boolean
     suspend fun add(element: T): Long
-    fun delete(element: T): Deferred<Unit>
+    suspend fun delete(element: T)
     fun update(from: T, to: T): Deferred<Unit>
     fun getAllTemporary(): Deferred<List<ArticleContext>>
     fun getAllPermanent(): Deferred<List<ArticleContext>>

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/CacheEntryClassifier.kt
@@ -9,7 +9,7 @@ interface CacheEntryClassifier<T>: UnfinishedDownloadSource {
     suspend fun contains(element : T): Boolean
     suspend fun add(element: T): Long
     suspend fun delete(element: T)
-    fun update(from: T, to: T): Deferred<Unit>
+    suspend fun update(from: T, to: T)
     fun getAllTemporary(): Deferred<List<ArticleContext>>
     fun getAllPermanent(): Deferred<List<ArticleContext>>
     fun markTemporary(element: T): Deferred<Unit>

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -1,8 +1,6 @@
 package com.greglaun.lector.data.whitelist
 
 import com.greglaun.lector.data.cache.*
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
 
 // A deterministic probabilistic set for testing
 class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
@@ -80,22 +78,21 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         }
     }
 
-    override fun getUnfinished(): Deferred<List<String>> {
+    override suspend fun getUnfinished(): List<String> {
         val result = ArrayList<ArticleContext>()
         hashMap.forEach{
             if (!it.value.downloadComplete) {
                 result.add(it.value)
             }
         }
-        return CompletableDeferred(result.toList().map { it.contextString })
+        return result.toList().map { it.contextString }
     }
 
-    override fun markFinished(element: String): Deferred<Unit> {
+    override suspend fun markFinished(element: String) {
         val originalEntry = hashMap.get(element)
         originalEntry?.let {
             hashMap.put(element, originalEntry.markDownloadComplete())
         }
-        return CompletableDeferred(Unit)
     }
 
     override suspend fun getNextArticle(context: String): ArticleContext? {

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -28,59 +28,56 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         }
     }
 
-    override fun getAllTemporary(): Deferred<List<ArticleContext>> {
+    override suspend fun getAllTemporary(): List<ArticleContext> {
         val result = ArrayList<ArticleContext>()
         hashMap.forEach{
             if (it.value.temporary) {
                 result.add(it.value)
             }
         }
-        return CompletableDeferred(result.toList())
+        return result.toList()
     }
 
-    override fun markTemporary(element: String): Deferred<Unit> {
+    override suspend fun markTemporary(element: String) {
         val originalEntry = hashMap.get(element)
         originalEntry?.let {
             hashMap.put(element, originalEntry.makeTemporary())
         }
-        return CompletableDeferred(Unit)
     }
 
-    override fun markPermanent(element: String): Deferred<Unit> {
+    override suspend fun markPermanent(element: String) {
         val originalEntry = hashMap.get(element)
         originalEntry?.let {
             hashMap.put(element, originalEntry.makePermanent())
         }
-        return CompletableDeferred(Unit)
     }
 
-    override fun isTemporary(element: String): Deferred<Boolean> {
+    override suspend fun isTemporary(element: String): Boolean {
         if (hashMap.containsKey(element)) {
-            return CompletableDeferred(hashMap.get(element)!!.temporary)
+            return hashMap.get(element)!!.temporary
         }
-        return CompletableDeferred(true)
+        return true
     }
 
-    override fun getAllPermanent(): Deferred<List<ArticleContext>> {
+    override suspend fun getAllPermanent(): List<ArticleContext> {
         val result = ArrayList<ArticleContext>()
         hashMap.forEach{
             if (!it.value.temporary) {
                 result.add(it.value)
             }
         }
-        return CompletableDeferred(result.toList())
+        return result.toList()
     }
 
-    override fun getArticleContext(context: String): Deferred<ArticleContext?> {
-        return CompletableDeferred(hashMap.get(context))
+    override suspend fun getArticleContext(context: String): ArticleContext? {
+        return hashMap.get(context)
     }
 
-    override fun updatePosition(currentRequestContext: String, position: String): Deferred<Unit> {
+    override suspend fun updatePosition(currentRequestContext: String, position: String) {
         val originalEntry = hashMap.get(currentRequestContext)
         originalEntry?.let {
             hashMap.put(currentRequestContext, originalEntry.updatePosition(position))
         }
-        return CompletableDeferred(Unit)
     }
 
     override fun getUnfinished(): Deferred<List<String>> {
@@ -101,7 +98,7 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         return CompletableDeferred(Unit)
     }
 
-    override fun getNextArticle(context: String): Deferred<ArticleContext?> {
-        return CompletableDeferred(null)
+    override suspend fun getNextArticle(context: String): ArticleContext? {
+        return null
     }
 }

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -21,12 +21,11 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         hashMap.remove(element)
     }
 
-    override fun update(from: String, to: String): Deferred<Unit> {
+    override suspend fun update(from: String, to: String) {
         if (hashMap.contains(from)) {
             hashMap.remove(from)
             hashMap.put(to, BasicArticleContext.fromString(to))
         }
-        return CompletableDeferred(Unit)
     }
 
     override fun getAllTemporary(): Deferred<List<ArticleContext>> {

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.experimental.Deferred
 class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
     val hashMap = HashMap<String, BasicArticleContext>()
 
-    override fun contains(element: String): Deferred<Boolean> {
-        return CompletableDeferred(hashMap.contains(element))
+    override suspend fun contains(element: String): Boolean {
+        return hashMap.contains(element)
     }
 
     override fun add(element : String): Deferred<Long> {

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -12,9 +12,9 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         return hashMap.contains(element)
     }
 
-    override fun add(element : String): Deferred<Long> {
+    override suspend fun add(element : String): Long {
         hashMap.put(element, BasicArticleContext.fromString(element))
-        return CompletableDeferred(1L)
+        return 1L
     }
 
     override fun delete(element: String): Deferred<Unit> {

--- a/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
+++ b/app/src/main/java/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifier.kt
@@ -17,9 +17,8 @@ class HashSetCacheEntryClassifier: CacheEntryClassifier<String> {
         return 1L
     }
 
-    override fun delete(element: String): Deferred<Unit> {
+    override suspend fun delete(element: String) {
         hashMap.remove(element)
-        return CompletableDeferred(Unit)
     }
 
     override fun update(from: String, to: String): Deferred<Unit> {

--- a/app/src/main/java/com/greglaun/lector/ui/course/CourseBrowserPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/course/CourseBrowserPresenter.kt
@@ -24,7 +24,7 @@ class CourseBrowserPresenter(val view: CourseBrowserContract.View,
 
     override suspend fun beginCourseDownload() {
         courseDownloader.downloadCourseMetadata()?.let {
-            it.await()?.let {
+            it?.let {
                 courseMetadatalist.clear()
                 courseMetadatalist.addAll(it)
                 view.onCourseListChanged()
@@ -41,7 +41,7 @@ class CourseBrowserPresenter(val view: CourseBrowserContract.View,
 
     override suspend fun onCourseDetailSelected(courseMetadata: CourseMetadata) {
         courseDownloader.fetchCourseDetails(courseMetadata)?.let {
-            it.await()?.let {
+            it?.let {
                 currentDetails = it
                 view.showCourseDetails(it)
             }
@@ -50,7 +50,7 @@ class CourseBrowserPresenter(val view: CourseBrowserContract.View,
 
     private fun onCourseSaved(courseDetails: ThinCourseDetails) {
         GlobalScope.launch {
-            courseSource.addCourseDetails(courseDetails).await()
+            courseSource.addCourseDetails(courseDetails)
             view.showToast("Course " + courseDetails.name + " added.")
         }
     }
@@ -58,8 +58,8 @@ class CourseBrowserPresenter(val view: CourseBrowserContract.View,
     override suspend fun onCoursesSaved(courseMetadata: List<CourseMetadata>) {
             courseMetadata.forEach {
                 courseDownloader.fetchCourseDetails(it)?.also {
-                    it.await()?.let {
-                        courseSource.addCourseDetails(it).await()
+                    it?.let {
+                        courseSource.addCourseDetails(it)
                 }
             }
         }

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainContract.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainContract.kt
@@ -8,7 +8,6 @@ import com.greglaun.lector.data.net.DownloadCompleter
 import com.greglaun.lector.ui.base.LectorPresenter
 import com.greglaun.lector.ui.base.LectorView
 import com.greglaun.lector.ui.speak.ArticleState
-import kotlinx.coroutines.experimental.Deferred
 import okhttp3.Response
 
 interface MainContract {
@@ -44,7 +43,7 @@ interface MainContract {
         suspend fun saveArticle()
         fun deleteRequested(articleContext: ArticleContext)
         suspend fun onUrlChanged(url : String)
-        fun onRequest(url : String) : Deferred<Response?>
+        suspend fun onRequest(url : String): Response?
         suspend fun onDisplayReadingList()
         fun onRewindOne()
         fun onForwardOne()

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainContract.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainContract.kt
@@ -55,7 +55,7 @@ interface MainContract {
         suspend fun courseDetailsRequested(courseContext: CourseContext)
         fun setHandsomeBritish(shouldBeBritish: Boolean)
         fun evaluateJavascript(js: String, callback: ((String) -> Unit)?)
-        fun onPageDownloadFinished(urlString: String)
+        suspend fun onPageDownloadFinished(urlString: String)
 
         // Preferences
         fun setSpeechRate(speechRate: Float)

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
@@ -119,7 +119,7 @@ class MainPresenter(val view : MainContract.View,
         view.loadUrl(urlString)
         stopSpeakingAndEnablePlayButton()
         var position = POSITION_BEGINNING
-        if (responseSource.contains(urlToContext(urlString)).await()) {
+        if (responseSource.contains(urlToContext(urlString))) {
                 responseSource.getArticleContext(urlToContext(urlString))
                         .await()?.let{
                             position = it.position
@@ -176,7 +176,7 @@ class MainPresenter(val view : MainContract.View,
                 }
                 computedContext = currentRequestContext
             }
-            if (!this@MainPresenter.responseSource.contains(computedContext).await()) {
+            if (!this@MainPresenter.responseSource.contains(computedContext)) {
                 responseSource.add(computedContext).await()
             }
         }

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
@@ -177,7 +177,7 @@ class MainPresenter(val view : MainContract.View,
                 computedContext = currentRequestContext
             }
             if (!this@MainPresenter.responseSource.contains(computedContext)) {
-                responseSource.add(computedContext).await()
+                responseSource.add(computedContext)
             }
         }
     }

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
@@ -6,7 +6,10 @@ import com.greglaun.lector.data.course.CourseSource
 import com.greglaun.lector.data.net.DownloadCompleter
 import com.greglaun.lector.data.net.DownloadCompletionScheduler
 import com.greglaun.lector.ui.speak.*
-import kotlinx.coroutines.experimental.*
+import kotlinx.coroutines.experimental.CoroutineScope
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.experimental.newSingleThreadContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -185,7 +188,7 @@ class MainPresenter(val view : MainContract.View,
         }
     }
 
-    override fun onRequest(url: String): Deferred<Response?> {
+    override suspend fun onRequest(url: String): Response? {
         var curContext: String? = null
         synchronized(currentRequestContext) {
             curContext = currentRequestContext
@@ -196,11 +199,8 @@ class MainPresenter(val view : MainContract.View,
     }
 
     override suspend fun saveArticle() {
-        synchronized(currentRequestContext) {
-            GlobalScope.launch {
-                responseSource.markPermanent(currentRequestContext)
-            }
-        }
+        val requestContextCopy = currentRequestContext
+        responseSource.markPermanent(requestContextCopy)
     }
 
     override suspend fun courseDetailsRequested(courseContext: CourseContext) {

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
@@ -82,7 +82,9 @@ class MainPresenter(val view : MainContract.View,
     }
 
     private fun autoDeleteCurrent(articleState: ArticleState) {
-        responseSource.delete(articleState.title)
+        GlobalScope.launch {
+            responseSource.delete(articleState.title)
+        }
     }
 
     private suspend fun autoPlayNext(articleState: ArticleState) {
@@ -213,7 +215,7 @@ class MainPresenter(val view : MainContract.View,
                 onConfirmed = {
                     if(it) {
                         GlobalScope.launch {
-                            responseSource.delete(articleContext.contextString).await()
+                            responseSource.delete(articleContext.contextString)
                             readingList.remove(articleContext)
                             view.onReadingListChanged()
                         }

--- a/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/main/MainPresenter.kt
@@ -207,7 +207,7 @@ class MainPresenter(val view : MainContract.View,
         courseContext.id?.let {
             currentCourse = courseContext.courseName
                 courseSource.getArticlesForCourse(it)?.let {
-                    displayArticleList(it.await(),
+                    displayArticleList(it,
                             courseContext.courseName)
                 }
         }
@@ -231,7 +231,7 @@ class MainPresenter(val view : MainContract.View,
                 onConfirmed = {
                     if(it) {
                         GlobalScope.launch {
-                            courseSource.delete(courseContext.courseName).await()
+                            courseSource.delete(courseContext.courseName)
                             courseList.remove(courseContext)
                             view.onCoursesChanged()
                         }
@@ -255,7 +255,7 @@ class MainPresenter(val view : MainContract.View,
     override suspend fun onDisplayCourses() {
         courseList.clear()
         courseSource.getCourses()?.let {
-            courseList.addAll(it.await())
+            courseList.addAll(it)
         }
         view.onCoursesChanged()
         view.displayCourses()
@@ -291,7 +291,7 @@ class MainPresenter(val view : MainContract.View,
         view.evaluateJavascript(js, callback)
     }
 
-    override fun onPageDownloadFinished(urlString: String) {
+    override suspend fun onPageDownloadFinished(urlString: String) {
         responseSource.markFinished(urlToContext(urlString))
     }
 

--- a/app/src/main/java/com/greglaun/lector/ui/speak/JSoupArticleStateSource.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/speak/JSoupArticleStateSource.kt
@@ -10,7 +10,7 @@ class JSoupArticleStateSource(val responseSource: ResponseSource) : ArticleState
         val cacheRequest = Request.Builder()
                 .url(urlString)
                 .build()
-        val html = responseSource.getWithContext(cacheRequest, urlToContext(urlString)).await()
+        val html = responseSource.getWithContext(cacheRequest, urlToContext(urlString))
         return articleStateFromHtml(html!!.peekBody(TEN_GB).string())
     }
 }

--- a/app/src/main/java/com/greglaun/lector/ui/speak/TtsPresenter.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/speak/TtsPresenter.kt
@@ -1,5 +1,8 @@
 package com.greglaun.lector.ui.speak
 
+import kotlinx.coroutines.experimental.GlobalScope
+import kotlinx.coroutines.experimental.launch
+
 class TtsPresenter(private val tts: TTSContract.AudioView,
                    val stateMachine: TtsStateMachine)
     : TTSContract.Presenter, TtsActorClient {
@@ -23,7 +26,9 @@ class TtsPresenter(private val tts: TTSContract.AudioView,
 
     override fun speakInLoop(onPositionUpdate: ((String) -> Unit)?) {
         this.onPositionUpdate = onPositionUpdate
-        stateMachine?.actionSpeakInLoop(onPositionUpdate)
+        GlobalScope.launch {
+            stateMachine?.actionSpeakInLoop(onPositionUpdate)
+        }
     }
 
     override fun stopSpeechViewImmediately() {
@@ -35,15 +40,21 @@ class TtsPresenter(private val tts: TTSContract.AudioView,
     }
 
     override fun stopSpeaking() {
-        stateMachine?.actionStopSpeaking()
+        GlobalScope.launch {
+            stateMachine?.actionStopSpeaking()
+        }
     }
 
     override fun advanceOne(onDone: (ArticleState) -> Unit) {
+        GlobalScope.launch {
             stateMachine?.stopAdvanceOneAndResume(onDone)
+        }
     }
 
     override fun reverseOne(onDone: (ArticleState) -> Unit) {
-        stateMachine?.stopReverseOneAndResume(onDone)
+        GlobalScope.launch {
+            stateMachine?.stopReverseOneAndResume(onDone)
+        }
     }
 
     override fun setHandsomeBritish(shouldBeBritish: Boolean) {
@@ -54,4 +65,3 @@ class TtsPresenter(private val tts: TTSContract.AudioView,
         tts.setSpeechRate(speechRate)
     }
 }
-

--- a/app/src/main/java/com/greglaun/lector/ui/speak/TtsStateMachine.kt
+++ b/app/src/main/java/com/greglaun/lector/ui/speak/TtsStateMachine.kt
@@ -1,19 +1,17 @@
 package com.greglaun.lector.ui.speak
 
-import kotlinx.coroutines.experimental.Deferred
-
 interface TtsStateMachine {
     fun startMachine(ttsActorClient: TtsActorClient, stateListener: TtsStateListener)
     fun stopMachine()
 
     suspend fun updateArticle(articleState: ArticleState)
 
-    fun actionSpeakInLoop(onPositionUpdate: ((String) -> Unit)?): Deferred<Unit>
-    fun getSpeakerState(): Deferred<SpeakerState>
-    fun actionSpeakOne(): Deferred<SpeakerState>
-    fun actionStopSpeaking(): Deferred<Unit?>
-    fun getArticleState(): Deferred<ArticleState>
+    suspend fun actionSpeakInLoop(onPositionUpdate: ((String) -> Unit)?)
+    suspend fun getSpeakerState(): SpeakerState
+    suspend fun actionSpeakOne(): SpeakerState
+    suspend fun actionStopSpeaking()
+    suspend fun getArticleState(): ArticleState
 
-    fun stopAdvanceOneAndResume(onDone: (ArticleState) -> Unit): Deferred<Unit>
-    fun stopReverseOneAndResume(onDone: (ArticleState) -> Unit): Deferred<Unit>
+    suspend fun stopAdvanceOneAndResume(onDone: (ArticleState) -> Unit)
+    suspend fun stopReverseOneAndResume(onDone: (ArticleState) -> Unit)
 }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -55,9 +55,9 @@ class ResponseSourceImplTest {
     @Test
     fun contains() {
         runBlocking {
-            assertFalse(responseSource!!.contains("Dog").await())
+            assertFalse(responseSource!!.contains("Dog"))
             responseSource!!.add("Dog").await()
-            assertTrue(responseSource!!.contains("Dog").await())
+            assertTrue(responseSource!!.contains("Dog"))
         }
     }
 
@@ -65,9 +65,9 @@ class ResponseSourceImplTest {
     fun delete() {
         runBlocking {
             responseSource!!.add("Dog").await()
-            assertTrue(responseSource!!.contains("Dog").await())
+            assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.delete("Dog").await()
-            assertFalse(responseSource!!.contains("Dog").await())
+            assertFalse(responseSource!!.contains("Dog"))
         }
     }
 
@@ -99,10 +99,10 @@ class ResponseSourceImplTest {
     fun update() {
         runBlocking {
             responseSource!!.add("Dog").await()
-            assertTrue(responseSource!!.contains("Dog").await())
+            assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.update("Dog", "Potato").await()
-            assertFalse(responseSource!!.contains("Dog").await())
-            assertTrue(responseSource!!.contains("Potato").await())
+            assertFalse(responseSource!!.contains("Dog"))
+            assertTrue(responseSource!!.contains("Potato"))
         }
     }
 

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -66,7 +66,7 @@ class ResponseSourceImplTest {
         runBlocking {
             responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
-            responseSource!!.delete("Dog").await()
+            responseSource!!.delete("Dog")
             assertFalse(responseSource!!.contains("Dog"))
         }
     }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -76,8 +76,8 @@ class ResponseSourceImplTest {
         val request = Request.Builder()
                 .url(dogUrlString)
                 .build()
-        var networkResponse : Response? = null
-        var cachedResponse : Response? = null
+        var networkResponse: Response?
+        var cachedResponse : Response?
         runBlocking {
             responseSource!!.add("Dog")
             // Response from network
@@ -109,21 +109,21 @@ class ResponseSourceImplTest {
     @Test
     fun markTemporary() {
         runBlocking {
-            assertEquals(responseSource!!.getAllTemporary().await().size, 0)
+            assertEquals(responseSource!!.getAllTemporary().size, 0)
             responseSource!!.add("Dog")
-            assertTrue(responseSource!!.isTemporary("Dog").await())
-            assertEquals(responseSource!!.getAllTemporary().await().size, 1)
-            assertEquals(responseSource!!.getAllPermanent().await().size, 0)
+            assertTrue(responseSource!!.isTemporary("Dog"))
+            assertEquals(responseSource!!.getAllTemporary().size, 1)
+            assertEquals(responseSource!!.getAllPermanent().size, 0)
 
-            responseSource!!.markPermanent("Dog").await()
-            assertFalse(responseSource!!.isTemporary("Dog").await())
-            assertEquals(responseSource!!.getAllTemporary().await().size, 0)
-            assertEquals(responseSource!!.getAllPermanent().await().size, 1)
+            responseSource!!.markPermanent("Dog")
+            assertFalse(responseSource!!.isTemporary("Dog"))
+            assertEquals(responseSource!!.getAllTemporary().size, 0)
+            assertEquals(responseSource!!.getAllPermanent().size, 1)
 
-            responseSource!!.markTemporary("Dog").await()
-            assertTrue(responseSource!!.isTemporary("Dog").await())
-            assertEquals(responseSource!!.getAllTemporary().await().size, 1)
-            assertEquals(responseSource!!.getAllPermanent().await().size, 0)
+            responseSource!!.markTemporary("Dog")
+            assertTrue(responseSource!!.isTemporary("Dog"))
+            assertEquals(responseSource!!.getAllTemporary().size, 1)
+            assertEquals(responseSource!!.getAllPermanent().size, 0)
         }
     }
 
@@ -135,7 +135,7 @@ class ResponseSourceImplTest {
         var networkResponse : Response? = null
 
         runBlocking {
-            assertEquals(responseSource!!.getAllTemporary().await().size, 0)
+            assertEquals(responseSource!!.getAllTemporary().size, 0)
             responseSource!!.add("Dog")
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             assertNotNull(networkResponse)
@@ -158,7 +158,7 @@ class ResponseSourceImplTest {
         var networkResponse: Response? = null
 
         runBlocking {
-            assertEquals(responseSource!!.getAllTemporary().await().size, 0)
+            assertEquals(responseSource!!.getAllTemporary().size, 0)
             responseSource!!.add("Dog")
             responseSource!!.markPermanent("Dog")
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
@@ -179,10 +179,10 @@ class ResponseSourceImplTest {
         runBlocking {
             responseSource!!.add("Dog")
             assertEquals(
-                    responseSource!!.getArticleContext("Dog").await()!!.position, "")
-            responseSource!!.updatePosition("Dog", "newPosition").await()
+                    responseSource!!.getArticleContext("Dog")!!.position, "")
+            responseSource!!.updatePosition("Dog", "newPosition")
             assertEquals(
-                    responseSource!!.getArticleContext("Dog").await()!!.position,
+                    responseSource!!.getArticleContext("Dog")!!.position,
                     "newPosition")
 
         }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -100,7 +100,7 @@ class ResponseSourceImplTest {
         runBlocking {
             responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
-            responseSource!!.update("Dog", "Potato").await()
+            responseSource!!.update("Dog", "Potato")
             assertFalse(responseSource!!.contains("Dog"))
             assertTrue(responseSource!!.contains("Potato"))
         }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -191,7 +191,7 @@ class ResponseSourceImplTest {
     fun getUnfinished() {
         runBlocking {
             responseSource!!.add("Dog")
-            assertEquals(responseSource!!.getUnfinished().await().size, 1)
+            assertEquals(responseSource!!.getUnfinished().size, 1)
         }
     }
 
@@ -199,9 +199,9 @@ class ResponseSourceImplTest {
     fun markFinished() {
         runBlocking {
             responseSource!!.add("Dog")
-            assertEquals(responseSource!!.getUnfinished().await().size, 1)
-            responseSource!!.markFinished("Dog").await()
-            assertEquals(responseSource!!.getUnfinished().await().size, 0)
+            assertEquals(responseSource!!.getUnfinished().size, 1)
+            responseSource!!.markFinished("Dog")
+            assertEquals(responseSource!!.getUnfinished().size, 0)
         }
     }
 }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -45,9 +45,9 @@ class ResponseSourceImplTest {
         runBlocking {
             responseSource!!.add("Dog")
             // Response from network
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             // Response is in cache now
-            cachedResponse = savedArticleCache.getWithContext(request, "Dog").await()
+            cachedResponse = savedArticleCache.getWithContext(request, "Dog")
         }
         assertTrue(networkResponse!!.body()!!.string() == cachedResponse!!.body()!!.string())
     }
@@ -81,16 +81,16 @@ class ResponseSourceImplTest {
         runBlocking {
             responseSource!!.add("Dog")
             // Response from network
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             testNetworkCache.disableNetwork = true
 
             cachedResponse = responseSource!!.articleCache.
-                    getWithContext(request!!, "Potato").await()
+                    getWithContext(request!!, "Potato")
             assertNull(cachedResponse)
 
             responseSource!!.setWithContext(request, networkResponse!!,
                     "Potato")
-            cachedResponse = responseSource!!.getWithContext(request!!, "Potato").await()
+            cachedResponse = responseSource!!.getWithContext(request!!, "Potato")
             assertTrue(networkResponse!!.body()!!.string() == cachedResponse!!.body()!!.string())
         }
     }
@@ -137,15 +137,15 @@ class ResponseSourceImplTest {
         runBlocking {
             assertEquals(responseSource!!.getAllTemporary().size, 0)
             responseSource!!.add("Dog")
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNotNull(networkResponse)
 
             testNetworkCache.disableNetwork = true
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNotNull(networkResponse)
 
-            responseSource!!.garbageCollectTemporary().await()
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            responseSource!!.garbageCollectTemporary()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNull(networkResponse)
         }
     }
@@ -161,15 +161,15 @@ class ResponseSourceImplTest {
             assertEquals(responseSource!!.getAllTemporary().size, 0)
             responseSource!!.add("Dog")
             responseSource!!.markPermanent("Dog")
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNotNull(networkResponse)
 
             testNetworkCache.disableNetwork = true
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNotNull(networkResponse)
 
-            responseSource!!.garbageCollectContext("Dog").await()
-            networkResponse = responseSource!!.getWithContext(request, "Dog").await()
+            responseSource!!.garbageCollectContext("Dog")
+            networkResponse = responseSource!!.getWithContext(request, "Dog")
             assertNull(networkResponse)
         }
     }
@@ -184,7 +184,6 @@ class ResponseSourceImplTest {
             assertEquals(
                     responseSource!!.getArticleContext("Dog")!!.position,
                     "newPosition")
-
         }
     }
 

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/ResponseSourceImplTest.kt
@@ -43,7 +43,7 @@ class ResponseSourceImplTest {
         var networkResponse : Response? = null
         var cachedResponse : Response? = null
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             // Response from network
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             // Response is in cache now
@@ -56,7 +56,7 @@ class ResponseSourceImplTest {
     fun contains() {
         runBlocking {
             assertFalse(responseSource!!.contains("Dog"))
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
         }
     }
@@ -64,7 +64,7 @@ class ResponseSourceImplTest {
     @Test
     fun delete() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.delete("Dog").await()
             assertFalse(responseSource!!.contains("Dog"))
@@ -79,7 +79,7 @@ class ResponseSourceImplTest {
         var networkResponse : Response? = null
         var cachedResponse : Response? = null
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             // Response from network
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             testNetworkCache.disableNetwork = true
@@ -98,7 +98,7 @@ class ResponseSourceImplTest {
     @Test
     fun update() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.contains("Dog"))
             responseSource!!.update("Dog", "Potato").await()
             assertFalse(responseSource!!.contains("Dog"))
@@ -110,7 +110,7 @@ class ResponseSourceImplTest {
     fun markTemporary() {
         runBlocking {
             assertEquals(responseSource!!.getAllTemporary().await().size, 0)
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertTrue(responseSource!!.isTemporary("Dog").await())
             assertEquals(responseSource!!.getAllTemporary().await().size, 1)
             assertEquals(responseSource!!.getAllPermanent().await().size, 0)
@@ -136,7 +136,7 @@ class ResponseSourceImplTest {
 
         runBlocking {
             assertEquals(responseSource!!.getAllTemporary().await().size, 0)
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             assertNotNull(networkResponse)
 
@@ -159,7 +159,7 @@ class ResponseSourceImplTest {
 
         runBlocking {
             assertEquals(responseSource!!.getAllTemporary().await().size, 0)
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             responseSource!!.markPermanent("Dog")
             networkResponse = responseSource!!.getWithContext(request, "Dog").await()
             assertNotNull(networkResponse)
@@ -177,7 +177,7 @@ class ResponseSourceImplTest {
     @Test
     fun updatePosition() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertEquals(
                     responseSource!!.getArticleContext("Dog").await()!!.position, "")
             responseSource!!.updatePosition("Dog", "newPosition").await()
@@ -191,7 +191,7 @@ class ResponseSourceImplTest {
     @Test
     fun getUnfinished() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertEquals(responseSource!!.getUnfinished().await().size, 1)
         }
     }
@@ -199,7 +199,7 @@ class ResponseSourceImplTest {
     @Test
     fun markFinished() {
         runBlocking {
-            responseSource!!.add("Dog").await()
+            responseSource!!.add("Dog")
             assertEquals(responseSource!!.getUnfinished().await().size, 1)
             responseSource!!.markFinished("Dog").await()
             assertEquals(responseSource!!.getUnfinished().await().size, 0)

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/SavedArticleCacheTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/cache/SavedArticleCacheTest.kt
@@ -40,16 +40,16 @@ class SavedArticleCacheTest {
 
         // Cache saved article cache should be empty
         runBlocking {
-            cachedResponse = savedArticleCache.getWithContext(request, "Dog").await()
+            cachedResponse = savedArticleCache.getWithContext(request, "Dog")
         }
         assertNull(cachedResponse)
 
         runBlocking {
             // Response from network
-            networkResponse = compositeCache.getWithContext(request, "Dog").await()
+            networkResponse = compositeCache.getWithContext(request, "Dog")
 
             // Response is in cache now
-            cachedResponse = savedArticleCache.getWithContext(request, "Dog").await()
+            cachedResponse = savedArticleCache.getWithContext(request, "Dog")
             assertTrue(networkResponse!!.body()!!.string() == cachedResponse!!.body()!!.string())
         }
     }
@@ -69,30 +69,30 @@ class SavedArticleCacheTest {
 
         runBlocking {
             // Response from network
-            networkDogResponse = compositeCache.getWithContext(dogRequest, "Dog").await()
-            networkCatResponse = compositeCache.getWithContext(catRequest, "Cat").await()
+            networkDogResponse = compositeCache.getWithContext(dogRequest, "Dog")
+            networkCatResponse = compositeCache.getWithContext(catRequest, "Cat")
 
             // Response is in cache now
-            cachedCatResponse = savedArticleCache.getWithContext(catRequest, "Cat").await()
-            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog").await()
+            cachedCatResponse = savedArticleCache.getWithContext(catRequest, "Cat")
+            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog")
         }
         assertTrue(networkDogResponse!!.peekBody(TEN_GB)!!.string() == cachedDogResponse!!.body()!!.string())
         assertTrue(networkCatResponse!!.body()!!.string() == cachedCatResponse!!.body()!!.string())
 
-        // Run garbage collection on a non-Dog contextString
-        savedArticleCache.garbageCollectContext("Cat")
         runBlocking {
-            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog").await()
+            // Run garbage collection on a non-Dog contextString
+            savedArticleCache.garbageCollectContext("Cat")
+            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog")
         }
         // Response should still be in cache
         assertTrue(networkDogResponse!!.body()!!.string() ==  cachedDogResponse!!.body()!!.string())
 
-        // Garbage collect Dog
-        savedArticleCache.garbageCollectContext("Dog")
-
-        // Cache saved article cache should be empty after Garbage Collection
         runBlocking {
-            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog").await()
+            // Garbage collect Dog
+            savedArticleCache.garbageCollectContext("Dog")
+
+            // Cache saved article cache should be empty after Garbage Collection
+            cachedDogResponse = savedArticleCache.getWithContext(dogRequest, "Dog")
         }
         assertNull(cachedDogResponse)
     }

--- a/app/src/test/integration/kotlin/com/greglaun/lector/data/course/CourseDownloaderImplTest.kt
+++ b/app/src/test/integration/kotlin/com/greglaun/lector/data/course/CourseDownloaderImplTest.kt
@@ -13,7 +13,7 @@ class CourseDownloaderImplTest {
     @Test
     fun downloadAllCourseNames() {
         runBlocking {
-            val result = courseDownloader.downloadCourseMetadata().await()
+            val result = courseDownloader.downloadCourseMetadata()
             assertTrue(result!!.contains(CourseMetadata("Ice Cream")))
             assertTrue(result!!.contains(CourseMetadata("Furry Friends")))
         }
@@ -23,7 +23,7 @@ class CourseDownloaderImplTest {
     fun fetchCourseDetails() {
         runBlocking {
             val detailsMap = courseDownloader.fetchCourseDetails(
-                    listOf("Ice Cream", "Furry Friends")).await()
+                    listOf("Ice Cream", "Furry Friends"))
             assertTrue(detailsMap!!.keys.size > 0)
             assertTrue(detailsMap!!.containsKey("Ice Cream"))
             assertTrue(detailsMap!!.containsKey("Furry Friends"))

--- a/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
@@ -43,8 +43,8 @@ class HashSetCacheEntryClassifierTest {
             classifier.markPermanent("apple")
             classifier.markPermanent("sauce")
             classifier.markTemporary("sauce")
-            val temporary = classifier.getAllTemporary().await()
-            val permanent = classifier.getAllPermanent().await()
+            val temporary = classifier.getAllTemporary()
+            val permanent = classifier.getAllPermanent()
             assertTrue(permanent.size == 1)
             assertTrue(permanent.contains(
                     BasicArticleContext(1L, "apple", "", false)))

--- a/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
@@ -29,7 +29,7 @@ class HashSetCacheEntryClassifierTest {
     fun delete() {
         runBlocking {
             classifier.add(testString)
-            classifier.delete(testString).await()
+            classifier.delete(testString)
             assertFalse(classifier.contains(testString))
         }
     }

--- a/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
@@ -13,7 +13,7 @@ class HashSetCacheEntryClassifierTest {
     @Test
     fun notContains() {
         runBlocking {
-            assertFalse(classifier.contains(testString).await())
+            assertFalse(classifier.contains(testString))
         }
     }
 
@@ -21,7 +21,7 @@ class HashSetCacheEntryClassifierTest {
     fun contains() {
         runBlocking {
             classifier.add(testString)
-            assertTrue(classifier.contains(testString).await())
+            assertTrue(classifier.contains(testString))
         }
     }
 
@@ -30,7 +30,7 @@ class HashSetCacheEntryClassifierTest {
         runBlocking {
             classifier.add(testString).await()
             classifier.delete(testString).await()
-            assertFalse(classifier.contains(testString).await())
+            assertFalse(classifier.contains(testString))
         }
     }
 

--- a/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/data/whitelist/HashSetCacheEntryClassifierTest.kt
@@ -28,7 +28,7 @@ class HashSetCacheEntryClassifierTest {
     @Test
     fun delete() {
         runBlocking {
-            classifier.add(testString).await()
+            classifier.add(testString)
             classifier.delete(testString).await()
             assertFalse(classifier.contains(testString))
         }
@@ -37,9 +37,9 @@ class HashSetCacheEntryClassifierTest {
     @Test
     fun temporaryAndPermanent() {
         runBlocking {
-            classifier.add("apple").await()
-            classifier.add("sauce").await()
-            classifier.add("pancakes").await()
+            classifier.add("apple")
+            classifier.add("sauce")
+            classifier.add("pancakes")
             classifier.markPermanent("apple")
             classifier.markPermanent("sauce")
             classifier.markTemporary("sauce")

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/course/CourseBrowserPresenterTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/course/CourseBrowserPresenterTest.kt
@@ -17,17 +17,17 @@ class CourseBrowserPresenterTest {
     fun beginCourseDownload() {
         runBlocking {
             courseBrowserPresenter.beginCourseDownload()
+            verify(mockDownloader, times(1)).downloadCourseMetadata()
         }
-        verify(mockDownloader, times(1)).downloadCourseMetadata()
     }
 
     @Test
     fun onCourseDetailSelected() {
         runBlocking {
-                courseBrowserPresenter.onCourseDetailSelected(CourseMetadata("A Course"))
-            }
+             courseBrowserPresenter.onCourseDetailSelected(CourseMetadata("A Course"))
             verify(mockDownloader, times(1)).
                     fetchCourseDetails(CourseMetadata("A Course"))
+        }
     }
 
     @Test

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
@@ -8,7 +8,6 @@ import com.greglaun.lector.data.course.ConcreteCourseContext
 import com.greglaun.lector.data.course.CourseSource
 import com.greglaun.lector.ui.speak.ArticleState
 import com.greglaun.lector.ui.speak.TTSContract
-import kotlinx.coroutines.experimental.CompletableDeferred
 import kotlinx.coroutines.experimental.runBlocking
 import org.junit.After
 import org.junit.Test
@@ -65,8 +64,7 @@ class MainPresenterTest {
         runBlocking {
             `when`(responseSource.contains(ArgumentMatchers.anyString())).thenReturn(
                     false)
-            `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(
-                    CompletableDeferred())
+            `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(0L)
             mainPresenter.onUrlChanged("test")
             verify(mockView, times(1)).loadUrl("test")
         }
@@ -94,10 +92,9 @@ class MainPresenterTest {
 
     @Test
     fun loadFromContext() {
-        `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(
-                CompletableDeferred(0L))
         val context = BasicArticleContext.fromString("Something")
         runBlocking {
+            `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(0L)
             `when`(responseSource.contains(ArgumentMatchers.anyString())).thenReturn(
                     false)
             mainPresenter.loadFromContext(context)

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
@@ -64,7 +64,7 @@ class MainPresenterTest {
     fun onUrlChanged() {
         runBlocking {
             `when`(responseSource.contains(ArgumentMatchers.anyString())).thenReturn(
-                    CompletableDeferred(false))
+                    false)
             `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(
                     CompletableDeferred())
             mainPresenter.onUrlChanged("test")
@@ -94,12 +94,12 @@ class MainPresenterTest {
 
     @Test
     fun loadFromContext() {
-        `when`(responseSource.contains(ArgumentMatchers.anyString())).thenReturn(
-                CompletableDeferred(false))
         `when`(responseSource.add(ArgumentMatchers.anyString())).thenReturn(
                 CompletableDeferred(0L))
         val context = BasicArticleContext.fromString("Something")
         runBlocking {
+            `when`(responseSource.contains(ArgumentMatchers.anyString())).thenReturn(
+                    false)
             mainPresenter.loadFromContext(context)
         }
         verify(mockView, times(1)).loadUrl(

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/main/MainPresenterTest.kt
@@ -141,8 +141,10 @@ class MainPresenterTest {
 
     @Test
     fun onPageDownloadFinished() {
-        mainPresenter.onPageDownloadFinished("A String")
-        verify(responseSource, times(1)).markFinished(
-                urlToContext("A String"))
+        runBlocking {
+            mainPresenter.onPageDownloadFinished("A String")
+            verify(responseSource, times(1)).markFinished(
+                    urlToContext("A String"))
+        }
     }
 }

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/speak/TtsActorStateMachineTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/speak/TtsActorStateMachineTest.kt
@@ -23,14 +23,14 @@ class TtsActorStateMachineTest {
         val articleState = ArticleState("Test", listOf("A", "B", "C"))
         stateMachine.startMachine(fakeClient, mockListener)
         runBlocking {
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.NOT_READY)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.NOT_READY)
             stateMachine.updateArticle(articleState)
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState)
 
             stateMachine.updateArticle(articleState.next()!!)
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState.next())
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState.next())
         }
     }
 
@@ -40,7 +40,7 @@ class TtsActorStateMachineTest {
         stateMachine.startMachine(fakeClient, mockListener)
         runBlocking {
             stateMachine.updateArticle(articleState)
-            stateMachine.actionSpeakOne().await()
+            stateMachine.actionSpeakOne()
             verify(mockListener, times(1)).onUtteranceStarted(articleState)
             verify(mockListener, times(1)).onUtteranceEnded(articleState)
             verify(mockListener, times(0)).onArticleFinished(articleState)
@@ -53,7 +53,7 @@ class TtsActorStateMachineTest {
         stateMachine.startMachine(fakeClient, mockListener)
         runBlocking {
             stateMachine.updateArticle(articleState)
-            stateMachine.actionSpeakInLoop {}.await()
+            stateMachine.actionSpeakInLoop {}
             stateMachine.SPEECH_LOOP!!.join()
 
             verify(mockListener, times(1)).onUtteranceStarted(articleState)
@@ -69,7 +69,7 @@ class TtsActorStateMachineTest {
 
             verify(mockListener, times(1)).onArticleFinished(cState)
 
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.NOT_READY)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.NOT_READY)
         }
     }
 
@@ -78,35 +78,35 @@ class TtsActorStateMachineTest {
         val articleState = ArticleState("Test", listOf("A", "B"))
         stateMachine.startMachine(fakeClient, mockListener)
         runBlocking {
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.NOT_READY)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.NOT_READY)
             stateMachine.updateArticle(articleState)
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState)
 
             // Attempting to seek past beginning of utterance list
             stateMachine.stopReverseOneAndResume {}
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState)
 
             // Now on B
             stateMachine.stopAdvanceOneAndResume {}
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState.next())
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState.next())
 
             // Now on A
             stateMachine.stopReverseOneAndResume {}
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState)
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState)
 
             // Now on B again
             stateMachine.stopAdvanceOneAndResume {}
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState.next())
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState.next())
 
             // Attempting to seek past end of utterance list
             stateMachine.stopAdvanceOneAndResume {}
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
-            assertEquals(stateMachine.getArticleState().await(), articleState.next())
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
+            assertEquals(stateMachine.getArticleState(), articleState.next())
         }
     }
 
@@ -117,9 +117,9 @@ class TtsActorStateMachineTest {
 
         runBlocking {
             stateMachine.updateArticle(articleState)
-            stateMachine.actionSpeakOne().await()
-            stateMachine.actionStopSpeaking().await()
-            assertEquals(stateMachine.getSpeakerState().await(), SpeakerState.READY)
+            stateMachine.actionSpeakOne()
+            stateMachine.actionStopSpeaking()
+            assertEquals(stateMachine.getSpeakerState(), SpeakerState.READY)
         }
     }
 }

--- a/app/src/test/unit/kotlin/com/greglaun/lector/ui/speak/TtsPresenterTest.kt
+++ b/app/src/test/unit/kotlin/com/greglaun/lector/ui/speak/TtsPresenterTest.kt
@@ -36,8 +36,10 @@ class TtsPresenterTest {
     @Test
     fun speakInLoop() {
         ttsPresenter!!.speakInLoop(null)
-        verify(stateMachine, times(1))!!
-                .actionSpeakInLoop(null)
+        runBlocking {
+            verify(stateMachine, times(1))!!
+                    .actionSpeakInLoop(null)
+        }
     }
 
     @Test
@@ -57,7 +59,9 @@ class TtsPresenterTest {
     @Test
     fun stopSpeaking() {
         ttsPresenter!!.stopSpeaking()
-        verify(stateMachine, times(1))!!.actionStopSpeaking()
+        runBlocking {
+            verify(stateMachine, times(1))!!.actionStopSpeaking()
+        }
     }
 
     @Test


### PR DESCRIPTION
Previously, functions returned Deferred<T> types. This PR cleans up the coroutines to be more idiomatic by marking the functions as suspend and returning T directly.